### PR TITLE
Make eip_validator pass on Travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -12,7 +12,7 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
-  bundle exec eip_validator EIPS/*.md
+  bundle exec eip_validator $(ls EIPS/*.md | grep "eip-\d*\.md")
 fi
 
 # Validate GH Pages DNS setup

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -12,7 +12,7 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
-  bundle exec eip_validator "EIPS/*.md"
+  bundle exec eip_validator EIPS/*.md
 fi
 
 # Validate GH Pages DNS setup

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -12,7 +12,7 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
-  bundle exec eip_validator $(ls EIPS/*.md | grep "eip-\d*\.md")
+  bundle exec eip_validator EIPS/*.md
 fi
 
 # Validate GH Pages DNS setup

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
-gem "eip_validator", ">=0.2.0"
+gem "eip_validator", ">=0.3.0"
 gem "front_matter_parser"
 gem "activemodel"
  

--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
-gem "eip_validator", ">=0.3.4"
+gem "eip_validator", ">=0.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
-gem "eip_validator", ">=0.3.3"
+gem "eip_validator", ">=0.3.4"

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", '>=3.3.1'
 
-gem "eip_validator", ">=0.3.0"
-gem "front_matter_parser"
-gem "activemodel"
- 
+gem "eip_validator", ">=0.3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,9 @@ GEM
     commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
-    eip_validator (0.2.0)
+    eip_validator (0.3.3)
+      activemodel
+      front_matter_parser (~> 0.1.1)
     ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -255,9 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel
-  eip_validator (>= 0.2.0)
-  front_matter_parser
+  eip_validator (>= 0.3.3)
   github-pages
   html-proofer (>= 3.3.1)
   jekyll (~> 3.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
-    eip_validator (0.3.3)
+    eip_validator (0.3.4)
       activemodel
       front_matter_parser (~> 0.1.1)
     ethon (0.11.0)
@@ -257,7 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  eip_validator (>= 0.3.3)
+  eip_validator (>= 0.3.4)
   github-pages
   html-proofer (>= 3.3.1)
   jekyll (~> 3.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
-    eip_validator (0.3.4)
+    eip_validator (0.4.0)
       activemodel
       front_matter_parser (~> 0.1.1)
     ethon (0.11.0)
@@ -257,7 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  eip_validator (>= 0.3.4)
+  eip_validator (>= 0.4.0)
   github-pages
   html-proofer (>= 3.3.1)
   jekyll (~> 3.6.2)


### PR DESCRIPTION
This PR includes the following

- Bump eip_validator to 0.3.4 which solves gem dependencies
- Bump eip_validator to 0.4.0 which solves filter out invalid EIP file names

![screen shot 2018-03-26 at 11 18 22](https://user-images.githubusercontent.com/2630/37883818-9f872d18-30e7-11e8-8962-a8f8119d7aba.png)
